### PR TITLE
Detect sending of emails using tab navigation and keyboard hotkeys

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -165,6 +165,16 @@ function showEldenRingBanner() {
   }, 3000);
 }
 
+const hotkeyHandler = (e) => { // Listen to hotkey for sending emails
+  if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+    console.log("Hotkey Ctrl+Enter or Cmd+Enter detected");
+    setTimeout(showEldenRingBanner, 500);
+  }
+};
+
+document.addEventListener('keydown', hotkeyHandler, true);
+console.log("Hotkey listener added");
+
 // gmail observer
 const gmailObserver = new MutationObserver(() => {
   document.querySelectorAll('div[role="button"], button[role="button"]').forEach(btn => {
@@ -182,6 +192,13 @@ const gmailObserver = new MutationObserver(() => {
       btn.addEventListener("click", () => {
         setTimeout(showEldenRingBanner, 500);
       });
+      // Handle tab nav keyboard activation
+      btn.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          setTimeout(showEldenRingBanner, 500);
+          console.log("Gmail send button activated via keyboard");
+        }
+      })
       btn.dataset.eldenRingAttached = "true";
     }
   });


### PR DESCRIPTION
Currently the banner does not appear in these 2 scenarios:
1) Tab navigating onto the send button and pressing Space or Enter to press the send button.
2) Using the default hotkey of Ctrl + Enter to send the email.

Added code to handle these scenarios :)